### PR TITLE
Fix hyperlinks in README.md

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -4,8 +4,8 @@
 
 🌈 Please use pull requests and issues to add to our repos
 
-👩‍💻 [Homepage i&i](www.ieni.org)
+👩‍💻 [Homepage i&i](https://www.ieni.org)
 
-🍿 [Keuzethemas](www.keuzethemas.nl)
+🍿 [Keuzethemas](https://www.keuzethemas.nl)
 
 🧙 Remember, you can do mighty things with the power of [Markdown](https://docs.github.com/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)


### PR DESCRIPTION
The links were seen as relative links, and thus were dead. By adding the full path they become absolute links and start working.